### PR TITLE
Ignore vendored libraries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+libraries/** linguist-vendored


### PR DESCRIPTION
代码统计被 `libraries/` 干废了。

参见 <https://github.com/github-linguist/linguist/blob/main/docs/overrides.md#vendored-code>
